### PR TITLE
feat: Add Gitpod configuration and VS Code buttons

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,12 @@
+FROM gitpod/workspace-full
+
+# Install Python dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Install Node.js and dependencies for the frontend
+COPY package.json package-lock.json ./
+RUN nvm install 20 && nvm use 20 && npm install
+
+# Copy the rest of the application code
+COPY . .

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,18 +1,25 @@
-# GitPod configuration for GenZ Trading Platform
-image: gitpod/workspace-python-3.11
+# GitPod configuration for GenX Trading Platform
+
+image:
+  file: .gitpod.Dockerfile
 
 tasks:
-  - name: Setup Python Environment
+  - name: Setup Environment
     init: |
-      pip install -r requirements.txt
+      echo "Setting up environment..."
+      # Copy the example environment file
+      cp .env.example .env
+      echo "Environment setup complete. Please configure your API keys in .env"
     command: |
-      echo "Python environment ready"
-  
-  - name: Setup Client Environment
-    init: |
-      cd client && npm install
+      echo "Workspace is ready!"
+
+  - name: Run Backend Server
     command: |
-      cd client && npm run dev
+      uvicorn api.main:app --host 0.0.0.0 --port 8000 --reload
+
+  - name: Run Frontend Server
+    command: |
+      npm run dev
 
 vscode:
   extensions:
@@ -25,7 +32,18 @@ vscode:
     - ms-azuretools.vscode-docker
 
 ports:
-  - port: 5173
-    onOpen: open-preview
   - port: 8000
-    onOpen: notify
+    onOpen: open-preview
+    name: "Backend API"
+  - port: 5173
+    onOpen: open-browser
+    name: "Frontend App"
+  - port: 5432
+    onOpen: ignore
+    name: "PostgreSQL"
+  - port: 6379
+    onOpen: ignore
+    name: "Redis"
+  - port: 27017
+    onOpen: ignore
+    name: "MongoDB"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # 🚀 GenX Trading Platform - Advanced AI-Powered Trading System
 
+[![Open in VS Code](https://open.vscode.dev/badges/open-in-vscode.svg)](https://open.vscode.dev/Mouy-leng/GenX-EA_Script)
+[![Open in VS Code Insiders](https://open.vscode.dev/badges/open-in-vscode-insiders.svg)](https://open.vscode.dev/Mouy-leng/GenX-EA_Script)
+
 [![GitHub License](https://img.shields.io/github/license/Mouy-leng/GenX-EA_Script)](https://github.com/Mouy-leng/GenX-EA_Script/blob/main/LICENSE)
 [![Docker](https://img.shields.io/badge/Docker-Ready-blue)](https://www.docker.com/)
 [![Python](https://img.shields.io/badge/Python-3.11+-green)](https://www.python.org/)


### PR DESCRIPTION
This commit introduces a Gitpod configuration to automate the development environment setup and adds "Open in VS Code" buttons to the README for easier access.

- Creates a `.gitpod.Dockerfile` to pre-build dependencies, speeding up workspace startup.
- Improves the `.gitpod.yml` to use the custom Dockerfile and streamline the setup process.
- Adds "Open in VS Code" and "Open in VS Code Insiders" buttons to the `README.md` file.