### PR TITLE
Fix: Add pytest.ini to resolve PYTHONPATH issues

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = .


### PR DESCRIPTION
When running pytest from the project root, it does not automatically add the current directory to the PYTHONPATH. This caused `ModuleNotFoundError` for absolute imports from the `api` and `core` directories within the test files.

This commit adds a `pytest.ini` file with the following configuration:

[pytest]
pythonpath = .

This tells pytest to add the project root to the PYTHONPATH, resolving the import errors and allowing the tests to run successfully.